### PR TITLE
Fake ime mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Number Keyboard  [![](https://jitpack.io/v/davidmigloz/number-keyboard.svg)](https://jitpack.io/#davidmigloz/number-keyboard)
 
-Android library that provides a number keyboard view.
+Android library that provides a number keyboard view. You can either add the keyboard view into your layout or use a
+popup that overlays your real IME (soft keyboard).
 
 ![screenshot](img/screenshot.jpg)
 
@@ -44,6 +45,26 @@ Use `NumberKeyboard` view in your layout:
     ... />
 ```
 
+Or use a `NumberKeyboardPopup` to intercept the IME showing:
+
+```java
+    popup = new NumberKeyboardPopup.Builder(findViewById(R.id.main_view)).setNumberKeyboardListener(this).setKeyboardLayout(R.layout.popup_keyboard).build(myEditText);
+
+        myEditText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!popup.isShowing()) {
+                    // Show numpad, this will also open the IME if it is not open yet
+                    popup.toggle();
+                }
+            }
+        });
+```
+
+Please note that currently this will always also open the IME so that the back button is correctly set to the
+"down button" and that the numpad fake IME is the correct size. The first time that the IME shows might be faster
+than the numpad IME popup showing, so you might see it for a split second.
+
 #### Attributes
 
 - `keyboard:keyboardType="[integer|decimal|fingerprint|custom]"` (required): defines the type of keyboard.
@@ -51,6 +72,7 @@ Use `NumberKeyboard` view in your layout:
   - `decimal`: numbers, comma and backspace keys.
   - `fingerprint`: numbers, fingerprint and backspace keys.
   - `custom`: numbers and defined auxiliary keys.
+  - `four_columns`: numbers and a fourth added column with comma, backspace, minus and enter
 - `keyboard:keyWidth="[dimension]"` (default: `match_parent`): key width (`wrap_content` not allowed).      
 - `keyboard:keyHeight="[dimension]"` (default: `match_parent`): key height (`wrap_content` not allowed).
 - `keyboard:keyPadding="[dimension]"` (default: `16dp`): key padding.
@@ -96,6 +118,9 @@ numberKeyboard.setListener(new NumberKeyboardListener() {
 
      @Override
      public void onRightAuxButtonClicked() {...}
+     
+     @Override
+     public void onModifierButtonClicked(int number) {...}
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,32 @@ numberKeyboard.setListener(new NumberKeyboardListener() {
 });
 ```
 
+#### "Fake IME" mode
+
+Instead of listening to keyboard events as shown in the last chapter, the NumberKeyboard can also be set up to
+send key events as an IME would. This means that no processing of events is necessary to get selection and deletion
+working.
+
+You can connect an EditText via
+
+```java
+numberKeyboard.editText = myEditText;
+
+// Or use with the popup like this:
+popup = new NumberKeyboardPopup.Builder(findViewById(R.id.main_view)).setEditTextListener();
+```
+
+You can combine this with setting a NumberKeyboardListener. To change which key sends the IME action, use these methods
+on the NumberKeyboard instance:
+
+```java
+// See the Javadoc of these functions for more information or the KeyboardEditTextPopupActivity sample.
+numberKeyboard.setLeftAuxButtonIsImeAction(true|false);
+numberKeyboard.setRightAuxBtnKeyEvent(KeyEvent.KEYCODE_COMMA);
+numberKeyboard.setModifierBtnKeyEvent(0, KeyEvent.KEYCODE_ENTER);
+```
+
+
 Take a look at the [sample app](https://github.com/davidmigloz/number-keyboard/tree/master/sample) to see the library working.
 
 ## Contributing

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         // Android Plugin for Gradle : https://developer.android.com/studio/releases/gradle-plugin.html#updating-plugin
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,3 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-org.gradle.configureondemand=false
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,6 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+org.gradle.configureondemand=false
+

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support:support-v4:27.1.1'
-    api 'com.android.support.constraint:constraint-layout:1.1.0'
+    api 'com.android.support.constraint:constraint-layout:1.1.2'
 }
 
 /**

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboard.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboard.java
@@ -269,7 +269,7 @@ public class NumberKeyboard extends ConstraintLayout {
             keyHeight = array.getLayoutDimension(R.styleable.NumberKeyboard_keyHeight, DEFAULT_KEY_HEIGHT_DP);
             // Get key padding
             keyPadding = array.getDimensionPixelSize(R.styleable.NumberKeyboard_keyPadding,
-                    dpToPx(DEFAULT_KEY_PADDING_DP));
+                    dpToPx(getContext(), DEFAULT_KEY_PADDING_DP));
             // Get number key background
             numberKeyBackground = array.getResourceId(R.styleable.NumberKeyboard_numberKeyBackground,
                     R.drawable.key_bg);
@@ -432,7 +432,7 @@ public class NumberKeyboard extends ConstraintLayout {
     /**
      * Utility method to convert dp to pixels.
      */
-    public int dpToPx(float valueInDp) {
-        return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, valueInDp, getResources().getDisplayMetrics());
+    public static int dpToPx(Context context, float valueInDp) {
+        return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, valueInDp, context.getResources().getDisplayMetrics());
     }
 }

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboard.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboard.java
@@ -59,6 +59,8 @@ public class NumberKeyboard extends ConstraintLayout {
     private ImageView rightAuxBtn;
 
     private NumberKeyboardListener listener;
+    private int layoutId = R.layout.number_keyboard;
+    private List<View> modifierKeys;
 
     public NumberKeyboard(@NonNull Context context) {
         super(context);
@@ -124,6 +126,11 @@ public class NumberKeyboard extends ConstraintLayout {
         }
         leftAuxBtn.getLayoutParams().width = px;
         rightAuxBtn.getLayoutParams().width = px;
+        if (modifierKeys != null) {
+            for (View modifierKey : modifierKeys) {
+                modifierKey.getLayoutParams().width = px;
+            }
+        }
         requestLayout();
     }
 
@@ -139,6 +146,11 @@ public class NumberKeyboard extends ConstraintLayout {
         }
         leftAuxBtn.getLayoutParams().height = px;
         rightAuxBtn.getLayoutParams().height = px;
+        if (modifierKeys != null) {
+            for (View modifierKey : modifierKeys) {
+                modifierKey.getLayoutParams().height = px;
+            }
+        }
         requestLayout();
     }
 
@@ -152,6 +164,14 @@ public class NumberKeyboard extends ConstraintLayout {
         }
         leftAuxBtn.setPadding(px, px, px, px);
         rightAuxBtn.setPadding(px, px, px, px);
+        if (modifierKeys != null) {
+            for (View modifierKey : modifierKeys) {
+                if (modifierKey instanceof TextView) {
+                    ((TextView)modifierKey).setCompoundDrawablePadding(-1 * px);
+                }
+                modifierKey.setPadding(px, px, px, px);
+            }
+        }
     }
 
     /**
@@ -160,6 +180,13 @@ public class NumberKeyboard extends ConstraintLayout {
     public void setNumberKeyBackground(@DrawableRes int background) {
         for (TextView key : numericKeys) {
             key.setBackground(ContextCompat.getDrawable(getContext(), background));
+        }
+        if (modifierKeys != null) {
+            for (View modifierKey : modifierKeys) {
+                if (modifierKey instanceof TextView) {
+                    modifierKey.setBackground(ContextCompat.getDrawable(getContext(), background));
+                }
+            }
         }
     }
 
@@ -170,6 +197,14 @@ public class NumberKeyboard extends ConstraintLayout {
         for (TextView key : numericKeys) {
             key.setTextColor(ContextCompat.getColorStateList(getContext(), color));
         }
+
+        if (modifierKeys != null) {
+            for (View modifierKey : modifierKeys) {
+                if (modifierKey instanceof TextView) {
+                    ((TextView)modifierKey).setTextColor(ContextCompat.getColorStateList(getContext(), color));
+                }
+            }
+        }
     }
 
     /**
@@ -178,6 +213,14 @@ public class NumberKeyboard extends ConstraintLayout {
     public void setNumberKeyTypeface(Typeface typeface) {
         for (TextView key : numericKeys) {
             key.setTypeface(typeface);
+        }
+
+        if (modifierKeys != null) {
+            for (View modifierKey : modifierKeys) {
+                if (modifierKey instanceof TextView) {
+                    ((TextView) modifierKey).setTypeface(typeface);
+                }
+            }
         }
     }
 
@@ -263,6 +306,13 @@ public class NumberKeyboard extends ConstraintLayout {
                     rightAuxBtnBackground = array.getResourceId(R.styleable.NumberKeyboard_rightAuxBtnBackground,
                             R.drawable.key_bg_transparent);
                     break;
+                case 4: // four rows
+                    leftAuxBtnIcon = R.drawable.key_bg_transparent;
+                    rightAuxBtnIcon = R.drawable.key_bg_transparent;
+                    leftAuxBtnBackground = R.drawable.key_bg_transparent;
+                    rightAuxBtnBackground = R.drawable.key_bg_transparent;
+                    layoutId = R.layout.number_keyboard_4rows;
+                    break;
                 default:
                     leftAuxBtnIcon = R.drawable.key_bg_transparent;
                     rightAuxBtnIcon = R.drawable.key_bg_transparent;
@@ -278,7 +328,7 @@ public class NumberKeyboard extends ConstraintLayout {
      * Inflates layout.
      */
     private void inflateView() {
-        View view = inflate(getContext(), R.layout.number_keyboard, this);
+        View view = inflate(getContext(), layoutId, this);
         // Get numeric keys
         numericKeys = new ArrayList<>(10);
         numericKeys.add((TextView) view.findViewById(R.id.key0));
@@ -294,6 +344,16 @@ public class NumberKeyboard extends ConstraintLayout {
         // Get auxiliary keys
         leftAuxBtn = view.findViewById(R.id.leftAuxBtn);
         rightAuxBtn = view.findViewById(R.id.rightAuxBtn);
+
+        // Check existence of and then get optional fourth row buttons
+        final View keyModifier1 = view.findViewById(R.id.keyModifier1);
+        if (keyModifier1 != null) {
+            modifierKeys = new ArrayList<>(4);
+            modifierKeys.add(keyModifier1);
+            modifierKeys.add(view.findViewById(R.id.keyModifier2));
+            modifierKeys.add(view.findViewById(R.id.buttonModifier3));
+            modifierKeys.add(view.findViewById(R.id.buttonModifier4));
+        }
         // Set styles
         setStyles();
         // Set listeners
@@ -349,6 +409,24 @@ public class NumberKeyboard extends ConstraintLayout {
                 }
             }
         });
+
+        if (modifierKeys != null) {
+            int i = 0;
+
+            for (View modifierKey : modifierKeys) {
+                final int modifierIdx = i;
+                i++;
+
+                modifierKey.setOnClickListener(new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (listener != null) {
+                            listener.onModifierButtonClicked(modifierIdx);
+                        }
+                    }
+                });
+            }
+        }
     }
 
     /**

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardListener.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardListener.java
@@ -34,4 +34,9 @@ public interface NumberKeyboardListener {
      * Invoked when the right auxiliary button is clicked.
      */
     void onRightAuxButtonClicked();
+
+    /**
+     * Invoked when a modifier button is clicked
+     */
+    void onModifierButtonClicked(int number);
 }

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
@@ -73,16 +73,14 @@ public class NumberKeyboardPopup {
         return size.y;
     }
 
-    private static Activity asActivity(@NonNull final Context context) {
-        Context result = context;
-
-        while (result instanceof ContextWrapper) {
-            if (result instanceof Activity) {
-                return (Activity) context;
-            }
-
-            result = ((ContextWrapper) context).getBaseContext();
-        }
+    @NonNull
+    private static Activity asActivity(Context cont) {
+        if (cont == null)
+            throw new IllegalArgumentException("The passed Context is not an Activity.");
+        else if (cont instanceof Activity)
+            return (Activity)cont;
+        else if (cont instanceof ContextWrapper)
+            return asActivity(((ContextWrapper)cont).getBaseContext());
 
         throw new IllegalArgumentException("The passed Context is not an Activity.");
     }

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
@@ -19,14 +19,16 @@ import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.PopupWindow;
 
+import static com.davidmiguel.numberkeyboard.NumberKeyboard.dpToPx;
+
 /**
  * Created by Kevin Read <me@kevin-read.com> on 14.08.18 for number-keyboard.
  * Copyright (c) 2018 BörseGo AG. All rights reserved.
  */
 public class NumberKeyboardPopup {
 
-    private static final long DELAY_HIDE_MS = 300l;
-    private static final long DELAY_SHOW_KEYBOARD_MS = 200l;
+    private static final long DELAY_HIDE_MS = 300L;
+    private static final long DELAY_SHOW_KEYBOARD_MS = 200L;
 
     public interface PopupListener {
         void onPopupVisibilityChanged(final boolean isShown);
@@ -37,31 +39,28 @@ public class NumberKeyboardPopup {
         void onKeyboardShown(int heightDifference);
     }
 
-    static final int MIN_KEYBOARD_HEIGHT = 100;
+    private static final int MIN_KEYBOARD_HEIGHT = 100;
 
-    final View rootView;
-    final Activity context;
+    private final View rootView;
+    private final Activity context;
 
     @NonNull
     final private NumberKeyboard keyboard;
 
-    final PopupWindow popupWindow;
+    private final PopupWindow popupWindow;
     final private EditText editText;
 
-    boolean isPendingOpen;
-    boolean isKeyboardOpen;
+    private boolean isPendingOpen;
+    private boolean isKeyboardOpen;
 
-    @NonNull static Rect windowVisibleDisplayFrame(@NonNull final Activity context) {
+    @NonNull
+    private static Rect windowVisibleDisplayFrame(@NonNull final Activity context) {
         final Rect result = new Rect();
         context.getWindow().getDecorView().getWindowVisibleDisplayFrame(result);
         return result;
     }
 
-    static int dpToPx(@NonNull final Context context, final float dp) {
-        return (int) (dp * context.getResources().getDisplayMetrics().density);
-    }
-
-    static int screenHeight(@NonNull final Activity context) {
+    private static int screenHeight(@NonNull final Activity context) {
         final Point size = new Point();
 
         context.getWindowManager().getDefaultDisplay().getSize(size);
@@ -69,7 +68,7 @@ public class NumberKeyboardPopup {
         return size.y;
     }
 
-    static Activity asActivity(@NonNull final Context context) {
+    private static Activity asActivity(@NonNull final Context context) {
         Context result = context;
 
         while (result instanceof ContextWrapper) {
@@ -83,15 +82,16 @@ public class NumberKeyboardPopup {
         throw new IllegalArgumentException("The passed Context is not an Activity.");
     }
 
-    @NonNull static Point locationOnScreen(@NonNull final View view) {
+    @NonNull
+    private static Point locationOnScreen(@NonNull final View view) {
         final int[] location = new int[2];
         view.getLocationOnScreen(location);
         return new Point(location[0], location[1]);
     }
 
-    static final int DONT_UPDATE_FLAG = -1;
+    private static final int DONT_UPDATE_FLAG = -1;
 
-    static void fixPopupLocation(@NonNull final PopupWindow popupWindow, @NonNull final Point desiredLocation) {
+    private static void fixPopupLocation(@NonNull final PopupWindow popupWindow, @NonNull final Point desiredLocation) {
         popupWindow.getContentView().post(new Runnable() {
             @Override public void run() {
                 final Point actualLocation = locationOnScreen(popupWindow.getContentView());
@@ -125,7 +125,7 @@ public class NumberKeyboardPopup {
     private PopupListener onPopupShownListener;
     @Nullable private KeyboardShownListener onSoftKeyboardShowListener;
 
-    final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
+    private final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
         @Override public void onGlobalLayout() {
             final Rect rect = windowVisibleDisplayFrame(context);
             final int heightDifference = screenHeight(context) - rect.bottom;
@@ -173,7 +173,9 @@ public class NumberKeyboardPopup {
         @Override
         public void run() {
             final InputMethodManager inputMethodManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-            inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+            if (inputMethodManager != null) {
+                inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+            }
         }
     };
 
@@ -224,7 +226,9 @@ public class NumberKeyboardPopup {
                 } else {
                     showAtBottomPending();
                     final InputMethodManager inputMethodManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-                    inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                    if (inputMethodManager != null) {
+                        inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                    }
                 }
 
 
@@ -245,7 +249,7 @@ public class NumberKeyboardPopup {
         popupWindow.dismiss();
     }
 
-    void showAtBottom() {
+    private void showAtBottom() {
         final Point desiredLocation = new Point(0, screenHeight(context) - popupWindow.getHeight());
 
         popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, desiredLocation.x, desiredLocation.y);
@@ -269,14 +273,9 @@ public class NumberKeyboardPopup {
         @Nullable private PopupListener onPopupShownListener;
         @Nullable private KeyboardShownListener onSoftKeyboardShownListener;
         @Nullable private NumberKeyboardListener onNumberKeyboardListener;
-        private @LayoutRes
-        int mKeyboardLayout;
-        private int keyboardLayout;
+        @LayoutRes private int keyboardLayout;
 
         public Builder(@NonNull final View rootView) {
-            if (rootView == null) {
-                throw new RuntimeException("Root view cannot be null");
-            }
             this.rootView = rootView;
         }
 
@@ -311,10 +310,6 @@ public class NumberKeyboardPopup {
         }
 
         @CheckResult public NumberKeyboardPopup build(@NonNull final EditText editText) {
-            if (editText == null) {
-                throw new RuntimeException("EditText cannot be null");
-            }
-
             final NumberKeyboardPopup popup = new NumberKeyboardPopup(rootView, editText, keyboardLayout);
             popup.onPopupShownListener = onPopupShownListener;
             popup.onSoftKeyboardShowListener = onSoftKeyboardShownListener;

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
@@ -158,7 +158,6 @@ public class NumberKeyboardPopup {
                     }
 
                     keyboard.postDelayed(delayHidePopupRunnable, DELAY_HIDE_MS);
-                    dismiss();
                     context.getWindow().getDecorView().getViewTreeObserver().removeOnGlobalLayoutListener(onGlobalLayoutListener);
                 }
             }

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
@@ -230,8 +230,6 @@ public class NumberKeyboardPopup {
                         inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
                     }
                 }
-
-
             }
         } else {
             dismiss();

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
@@ -22,6 +22,11 @@ import android.widget.PopupWindow;
 import static com.davidmiguel.numberkeyboard.NumberKeyboard.dpToPx;
 
 /**
+ * Create a popup window that shows as soon as the IME (soft keyboard) shows and overlays the keyboard. It will show
+ * a number pad as per the layout.
+ *
+ * This is loosely based on the excellent popup / IME handling in https://github.com/vanniktech/Emoji (also under Apache License)
+ *
  * Created by Kevin Read <me@kevin-read.com> on 14.08.18 for number-keyboard.
  * Copyright (c) 2018 BörseGo AG. All rights reserved.
  */

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
@@ -1,0 +1,327 @@
+package com.davidmiguel.numberkeyboard;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.graphics.Bitmap;
+import android.graphics.Point;
+import android.graphics.Rect;
+import android.graphics.drawable.BitmapDrawable;
+import android.support.annotation.CheckResult;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import android.widget.PopupWindow;
+
+/**
+ * Created by Kevin Read <me@kevin-read.com> on 14.08.18 for number-keyboard.
+ * Copyright (c) 2018 BörseGo AG. All rights reserved.
+ */
+public class NumberKeyboardPopup {
+
+    private static final long DELAY_HIDE_MS = 300l;
+    private static final long DELAY_SHOW_KEYBOARD_MS = 200l;
+
+    public interface PopupListener {
+        void onPopupVisibilityChanged(final boolean isShown);
+    }
+
+    public interface KeyboardShownListener {
+        void onKeyboardGone();
+        void onKeyboardShown(int heightDifference);
+    }
+
+    static final int MIN_KEYBOARD_HEIGHT = 100;
+
+    final View rootView;
+    final Activity context;
+
+    @NonNull
+    final private NumberKeyboard keyboard;
+
+    final PopupWindow popupWindow;
+    final private EditText editText;
+
+    boolean isPendingOpen;
+    boolean isKeyboardOpen;
+
+    @NonNull static Rect windowVisibleDisplayFrame(@NonNull final Activity context) {
+        final Rect result = new Rect();
+        context.getWindow().getDecorView().getWindowVisibleDisplayFrame(result);
+        return result;
+    }
+
+    static int dpToPx(@NonNull final Context context, final float dp) {
+        return (int) (dp * context.getResources().getDisplayMetrics().density);
+    }
+
+    static int screenHeight(@NonNull final Activity context) {
+        final Point size = new Point();
+
+        context.getWindowManager().getDefaultDisplay().getSize(size);
+
+        return size.y;
+    }
+
+    static Activity asActivity(@NonNull final Context context) {
+        Context result = context;
+
+        while (result instanceof ContextWrapper) {
+            if (result instanceof Activity) {
+                return (Activity) context;
+            }
+
+            result = ((ContextWrapper) context).getBaseContext();
+        }
+
+        throw new IllegalArgumentException("The passed Context is not an Activity.");
+    }
+
+    @NonNull static Point locationOnScreen(@NonNull final View view) {
+        final int[] location = new int[2];
+        view.getLocationOnScreen(location);
+        return new Point(location[0], location[1]);
+    }
+
+    static final int DONT_UPDATE_FLAG = -1;
+
+    static void fixPopupLocation(@NonNull final PopupWindow popupWindow, @NonNull final Point desiredLocation) {
+        popupWindow.getContentView().post(new Runnable() {
+            @Override public void run() {
+                final Point actualLocation = locationOnScreen(popupWindow.getContentView());
+
+                if (!(actualLocation.x == desiredLocation.x && actualLocation.y == desiredLocation.y)) {
+                    final int differenceX = actualLocation.x - desiredLocation.x;
+                    final int differenceY = actualLocation.y - desiredLocation.y;
+
+                    final int fixedOffsetX;
+                    final int fixedOffsetY;
+
+                    if (actualLocation.x > desiredLocation.x) {
+                        fixedOffsetX = desiredLocation.x - differenceX;
+                    } else {
+                        fixedOffsetX = desiredLocation.x + differenceX;
+                    }
+
+                    if (actualLocation.y > desiredLocation.y) {
+                        fixedOffsetY = desiredLocation.y - differenceY;
+                    } else {
+                        fixedOffsetY = desiredLocation.y + differenceY;
+                    }
+
+                    popupWindow.update(fixedOffsetX, fixedOffsetY, DONT_UPDATE_FLAG, DONT_UPDATE_FLAG);
+                }
+            }
+        });
+    }
+
+    @Nullable
+    private PopupListener onPopupShownListener;
+    @Nullable private KeyboardShownListener onSoftKeyboardShowListener;
+
+    final ViewTreeObserver.OnGlobalLayoutListener onGlobalLayoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
+        @Override public void onGlobalLayout() {
+            final Rect rect = windowVisibleDisplayFrame(context);
+            final int heightDifference = screenHeight(context) - rect.bottom;
+
+            if (heightDifference > dpToPx(context, MIN_KEYBOARD_HEIGHT)) {
+                popupWindow.setHeight(heightDifference);
+                popupWindow.setWidth(rect.right);
+
+                if (!isKeyboardOpen && onSoftKeyboardShowListener != null) {
+                    onSoftKeyboardShowListener.onKeyboardShown(heightDifference);
+                }
+
+                isKeyboardOpen = true;
+
+                if (isPendingOpen) {
+                    showAtBottom();
+                    isPendingOpen = false;
+                }
+            } else {
+                if (isKeyboardOpen) {
+                    isKeyboardOpen = false;
+
+                    if (onSoftKeyboardShowListener != null) {
+                        onSoftKeyboardShowListener.onKeyboardGone();
+                    }
+
+                    keyboard.postDelayed(delayHidePopupRunnable, DELAY_HIDE_MS);
+                    dismiss();
+                    context.getWindow().getDecorView().getViewTreeObserver().removeOnGlobalLayoutListener(onGlobalLayoutListener);
+                }
+            }
+        }
+    };
+
+    private Runnable delayHidePopupRunnable = new Runnable() {
+
+        @Override
+        public void run() {
+            dismiss();
+        }
+    };
+
+    private Runnable delayShowKeyboardRunnable = new Runnable() {
+
+        @Override
+        public void run() {
+            final InputMethodManager inputMethodManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+            inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+        }
+    };
+
+    NumberKeyboardPopup(@NonNull final View rootView, @NonNull final EditText editText, int keyboardLayout) {
+        this.context = asActivity(rootView.getContext());
+        this.rootView = rootView.getRootView();
+        this.editText = editText;
+
+        popupWindow = new PopupWindow(context);
+
+        if (keyboardLayout != 0) {
+            keyboard = (NumberKeyboard) context.getLayoutInflater().inflate(keyboardLayout, (ViewGroup)popupWindow.getContentView(), false);
+        } else {
+            keyboard = new NumberKeyboard(context);
+        }
+
+        popupWindow.setContentView(keyboard);
+        popupWindow.setInputMethodMode(PopupWindow.INPUT_METHOD_NOT_NEEDED);
+        popupWindow.setBackgroundDrawable(new BitmapDrawable(context.getResources(), (Bitmap) null)); // To avoid borders and overdraw.
+        popupWindow.setOnDismissListener(new PopupWindow.OnDismissListener() {
+            @Override public void onDismiss() {
+                if (onPopupShownListener != null) {
+                    onPopupShownListener.onPopupVisibilityChanged(false);
+                }
+            }
+        });
+    }
+
+    public void toggle() {
+        if (!popupWindow.isShowing()) {
+            // Remove any previous listeners to avoid duplicates.
+            context.getWindow().getDecorView().getViewTreeObserver().removeOnGlobalLayoutListener(onGlobalLayoutListener);
+            context.getWindow().getDecorView().getViewTreeObserver().addOnGlobalLayoutListener(onGlobalLayoutListener);
+
+            if (isKeyboardOpen) {
+                // If the keyboard is visible, simply show the emoji popup.
+                showAtBottom();
+            } else {
+                // Open the text keyboard first and immediately after that show the emoji popup.
+                editText.setFocusableInTouchMode(true);
+                editText.requestFocus();
+
+                // If we know the height of the IME already, open right away
+                if (popupWindow.getHeight() >= MIN_KEYBOARD_HEIGHT) {
+                    showAtBottom();
+
+                    keyboard.postDelayed(delayShowKeyboardRunnable, DELAY_SHOW_KEYBOARD_MS);
+                } else {
+                    showAtBottomPending();
+                    final InputMethodManager inputMethodManager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+                    inputMethodManager.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT);
+                }
+
+
+            }
+        } else {
+            dismiss();
+        }
+
+        // Manually dispatch the event. In some cases this does not work out of the box reliably.
+        context.getWindow().getDecorView().getViewTreeObserver().dispatchOnGlobalLayout();
+    }
+
+    public boolean isShowing() {
+        return popupWindow.isShowing();
+    }
+
+    public void dismiss() {
+        popupWindow.dismiss();
+    }
+
+    void showAtBottom() {
+        final Point desiredLocation = new Point(0, screenHeight(context) - popupWindow.getHeight());
+
+        popupWindow.showAtLocation(rootView, Gravity.NO_GRAVITY, desiredLocation.x, desiredLocation.y);
+        fixPopupLocation(popupWindow, desiredLocation);
+
+        if (onPopupShownListener != null) {
+            onPopupShownListener.onPopupVisibilityChanged(true);
+        }
+    }
+
+    private void showAtBottomPending() {
+        if (isKeyboardOpen) {
+            showAtBottom();
+        } else {
+            isPendingOpen = true;
+        }
+    }
+
+    public static final class Builder {
+        @NonNull private final View rootView;
+        @Nullable private PopupListener onPopupShownListener;
+        @Nullable private KeyboardShownListener onSoftKeyboardShownListener;
+        @Nullable private NumberKeyboardListener onNumberKeyboardListener;
+        private @LayoutRes
+        int mKeyboardLayout;
+        private int keyboardLayout;
+
+        public Builder(@NonNull final View rootView) {
+            if (rootView == null) {
+                throw new RuntimeException("Root view cannot be null");
+            }
+            this.rootView = rootView;
+        }
+
+        /**
+         * @param rootView The root View of your layout.xml which will be used for calculating the height
+         *                 of the keyboard.
+         * @return builder For building the {@link NumberKeyboardPopup}.
+         */
+        @CheckResult
+        public static Builder fromRootView(final View rootView) {
+            return new Builder(rootView);
+        }
+
+        @CheckResult public Builder setOnSoftKeyboardShownListener(@Nullable final KeyboardShownListener listener) {
+            onSoftKeyboardShownListener = listener;
+            return this;
+        }
+
+        @CheckResult public Builder setPopupListener(@Nullable final PopupListener listener) {
+            onPopupShownListener = listener;
+            return this;
+        }
+
+        @CheckResult public Builder setNumberKeyboardListener(@Nullable final NumberKeyboardListener listener) {
+            onNumberKeyboardListener = listener;
+            return this;
+        }
+
+        @CheckResult public Builder setKeyboardLayout(@LayoutRes int keyboardLayout) {
+            this.keyboardLayout = keyboardLayout;
+            return this;
+        }
+
+        @CheckResult public NumberKeyboardPopup build(@NonNull final EditText editText) {
+            if (editText == null) {
+                throw new RuntimeException("EditText cannot be null");
+            }
+
+            final NumberKeyboardPopup popup = new NumberKeyboardPopup(rootView, editText, keyboardLayout);
+            popup.onPopupShownListener = onPopupShownListener;
+            popup.onSoftKeyboardShowListener = onSoftKeyboardShownListener;
+            popup.keyboard.setListener(onNumberKeyboardListener);
+
+            return popup;
+        }
+
+    }
+}

--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboardPopup.java
@@ -183,7 +183,7 @@ public class NumberKeyboardPopup {
         }
     };
 
-    NumberKeyboardPopup(@NonNull final View rootView, @NonNull final EditText editText, int keyboardLayout) {
+    NumberKeyboardPopup(@NonNull final View rootView, @NonNull final EditText editText, int keyboardLayout, final boolean setEditTextListener) {
         this.context = asActivity(rootView.getContext());
         this.rootView = rootView.getRootView();
         this.editText = editText;
@@ -194,6 +194,10 @@ public class NumberKeyboardPopup {
             keyboard = (NumberKeyboard) context.getLayoutInflater().inflate(keyboardLayout, (ViewGroup)popupWindow.getContentView(), false);
         } else {
             keyboard = new NumberKeyboard(context);
+        }
+
+        if (setEditTextListener) {
+            keyboard.setEditText(editText);
         }
 
         popupWindow.setContentView(keyboard);
@@ -276,6 +280,7 @@ public class NumberKeyboardPopup {
         @Nullable private KeyboardShownListener onSoftKeyboardShownListener;
         @Nullable private NumberKeyboardListener onNumberKeyboardListener;
         @LayoutRes private int keyboardLayout;
+        private boolean doSetEditTextListener;
 
         public Builder(@NonNull final View rootView) {
             this.rootView = rootView;
@@ -311,14 +316,22 @@ public class NumberKeyboardPopup {
             return this;
         }
 
+        /**
+         * Pretend to be an IME and send key events to the edit text
+         * @return this builder instance
+         */
+        @CheckResult public Builder setEditTextListener() {
+            doSetEditTextListener = true;
+            return this;
+        }
+
         @CheckResult public NumberKeyboardPopup build(@NonNull final EditText editText) {
-            final NumberKeyboardPopup popup = new NumberKeyboardPopup(rootView, editText, keyboardLayout);
+            final NumberKeyboardPopup popup = new NumberKeyboardPopup(rootView, editText, keyboardLayout, doSetEditTextListener);
             popup.onPopupShownListener = onPopupShownListener;
             popup.onSoftKeyboardShowListener = onSoftKeyboardShownListener;
             popup.keyboard.setListener(onNumberKeyboardListener);
 
             return popup;
         }
-
     }
 }

--- a/lib/src/main/res/drawable/ic_check_circle.xml
+++ b/lib/src/main/res/drawable/ic_check_circle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_check_circle_pressed"
+        android:state_pressed="true"/>
+    <item android:drawable="@drawable/ic_check_circle_normal"/>
+</selector>

--- a/lib/src/main/res/drawable/ic_check_circle_normal.xml
+++ b/lib/src/main/res/drawable/ic_check_circle_normal.xml
@@ -1,0 +1,5 @@
+<vector android:height="50dp" android:tint="#1B1A51"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="50dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/lib/src/main/res/drawable/ic_check_circle_pressed.xml
+++ b/lib/src/main/res/drawable/ic_check_circle_pressed.xml
@@ -1,0 +1,5 @@
+<vector android:height="50dp" android:tint="#FFB638"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="50dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/lib/src/main/res/layout/number_keyboard_4rows.xml
+++ b/lib/src/main/res/layout/number_keyboard_4rows.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key1Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key4Container"
+        app:layout_constraintEnd_toStartOf="@+id/key2Container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/key1"
+            style="@style/key"
+            android:text="@string/one"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key2Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key5Container"
+        app:layout_constraintEnd_toStartOf="@+id/key3Container"
+        app:layout_constraintStart_toEndOf="@+id/key1Container"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/key2"
+            style="@style/key"
+            android:text="@string/two"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key3Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key6Container"
+        app:layout_constraintEnd_toStartOf="@+id/modifier1Container"
+        app:layout_constraintStart_toEndOf="@+id/key2Container"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/key3"
+            style="@style/key"
+            android:text="@string/three"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/modifier1Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key6Container"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/key3Container"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/keyModifier1"
+            style="@style/key"
+            android:text="@string/minus"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key4Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key7Container"
+        app:layout_constraintEnd_toStartOf="@+id/key5Container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/key1Container">
+
+        <TextView
+            android:id="@+id/key4"
+            style="@style/key"
+            android:text="@string/four"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key5Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key8Container"
+        app:layout_constraintEnd_toStartOf="@+id/key6Container"
+        app:layout_constraintStart_toEndOf="@+id/key4Container"
+        app:layout_constraintTop_toBottomOf="@+id/key2Container">
+
+        <TextView
+            android:id="@+id/key5"
+            style="@style/key"
+            android:text="@string/five"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key6Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key9Container"
+        app:layout_constraintEnd_toStartOf="@+id/modifier2Container"
+        app:layout_constraintStart_toEndOf="@+id/key5Container"
+        app:layout_constraintTop_toBottomOf="@+id/key3Container">
+
+        <TextView
+            android:id="@+id/key6"
+            style="@style/key"
+            android:text="@string/six"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/modifier2Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key9Container"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/key6Container"
+        app:layout_constraintTop_toBottomOf="@+id/key3Container">
+
+        <TextView
+            android:id="@+id/keyModifier2"
+            style="@style/key"
+            android:text="@string/comma"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key7Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/leftAuxBtnContainer"
+        app:layout_constraintEnd_toStartOf="@+id/key8Container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/key4Container">
+
+        <TextView
+            android:id="@+id/key7"
+            style="@style/key"
+            android:text="@string/seven"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key8Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/key0Container"
+        app:layout_constraintEnd_toStartOf="@+id/key9Container"
+        app:layout_constraintStart_toEndOf="@+id/key7Container"
+        app:layout_constraintTop_toBottomOf="@+id/key5Container">
+
+        <TextView
+            android:id="@+id/key8"
+            style="@style/key"
+            android:text="@string/eight"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key9Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/rightAuxBtnContainer"
+        app:layout_constraintEnd_toStartOf="@+id/modifier3Container"
+        app:layout_constraintStart_toEndOf="@+id/key8Container"
+        app:layout_constraintTop_toBottomOf="@+id/key6Container">
+
+        <TextView
+            android:id="@+id/key9"
+            style="@style/key"
+            android:text="@string/nine"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/modifier3Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toTopOf="@+id/rightAuxBtnContainer"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/key9Container"
+        app:layout_constraintTop_toBottomOf="@+id/key6Container">
+
+        <ImageView
+            android:id="@+id/buttonModifier3"
+            style="@style/keyNoBg"
+            android:scaleType="center"
+            app:srcCompat="@drawable/ic_backspace"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/leftAuxBtnContainer"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/key0Container"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/key7Container">
+
+        <ImageView
+            android:id="@+id/leftAuxBtn"
+            style="@style/key"
+            android:scaleType="center"
+            app:srcCompat="@drawable/ic_fingerprint"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/key0Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/rightAuxBtnContainer"
+        app:layout_constraintStart_toEndOf="@+id/leftAuxBtnContainer"
+        app:layout_constraintTop_toBottomOf="@+id/key8Container">
+
+        <TextView
+            android:id="@+id/key0"
+            style="@style/key"
+            android:text="@string/zero"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/rightAuxBtnContainer"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/modifier4Container"
+        app:layout_constraintStart_toEndOf="@+id/key0Container"
+        app:layout_constraintTop_toBottomOf="@+id/key9Container">
+
+        <ImageView
+            android:id="@+id/rightAuxBtn"
+            style="@style/key"
+            android:scaleType="center"
+            app:srcCompat="@drawable/ic_backspace"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+
+    <com.davidmiguel.numberkeyboard.SquareFrameLayout
+        android:id="@+id/modifier4Container"
+        style="@style/keyContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/rightAuxBtnContainer"
+        app:layout_constraintTop_toBottomOf="@+id/key9Container">
+
+        <ImageView
+            android:id="@+id/buttonModifier4"
+            style="@style/keyNoBg"
+            android:scaleType="center"
+            app:srcCompat="@drawable/ic_check_circle"/>
+
+    </com.davidmiguel.numberkeyboard.SquareFrameLayout>
+</merge>

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -6,7 +6,7 @@
         <enum name="decimal" value="1"/>
         <enum name="fingerprint" value="2"/>
         <enum name="custom" value="3"/>
-        <enum name="four_rows" value="4"/>
+        <enum name="four_columns" value="4"/>
     </attr>
 
     <attr name="keyWidth" format="dimension">

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -6,6 +6,7 @@
         <enum name="decimal" value="1"/>
         <enum name="fingerprint" value="2"/>
         <enum name="custom" value="3"/>
+        <enum name="four_rows" value="4"/>
     </attr>
 
     <attr name="keyWidth" format="dimension">

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="seven">7</string>
     <string name="eight">8</string>
     <string name="nine">9</string>
+    <string name="minus">-</string>
+    <string name="comma">,</string>
 </resources>

--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="key">
+    <style name="keyNoBg">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">match_parent</item>
         <item name="android:layout_gravity">center</item>
         <item name="android:gravity">center</item>
         <item name="android:clickable">true</item>
         <item name="android:layout_margin">8dp</item>
-        <item name="android:background">@drawable/key_bg</item>
         <item name="android:padding">16dp</item>
         <item name="android:drawablePadding">-16dp</item>
         <item name="android:includeFontPadding">false</item>
         <item name="android:lineSpacingExtra">0dp</item>
         <item name="autoSizeTextType">uniform</item>
+    </style>
+    <style name="key" parent="keyNoBg">
+        <item name="android:background">@drawable/key_bg</item>
     </style>
 
     <style name="keyContainer">

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity android:name="com.davidmiguel.sample.KeyboardDecimalActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardFingerprintActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardCustomActivity" />
+        <activity android:name=".KeyboardEditTextPopupActivity" />
         <activity android:name=".KeyboardPopupActivity" />
 
     </application>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity android:name="com.davidmiguel.sample.KeyboardDecimalActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardFingerprintActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardCustomActivity" />
+        <activity android:name=".KeyboardPopupActivity" />
 
     </application>
 

--- a/sample/src/main/java/com/davidmiguel/sample/KeyboardCustomActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/KeyboardCustomActivity.java
@@ -48,6 +48,11 @@ public class KeyboardCustomActivity extends AppCompatActivity implements NumberK
         showAmount();
     }
 
+    @Override
+    public void onModifierButtonClicked(int number) {
+        // Keyboard has no modifiers
+    }
+
     private void showAmount() {
         amountEditText.setText(nf.format(amount));
     }

--- a/sample/src/main/java/com/davidmiguel/sample/KeyboardEditTextPopupActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/KeyboardEditTextPopupActivity.java
@@ -1,0 +1,143 @@
+package com.davidmiguel.sample;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Log;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import com.davidmiguel.numberkeyboard.NumberKeyboardPopup;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.text.ParseException;
+
+/**
+ * Created by Kevin Read <me@kevin-read.com> on 21.08.18 for number-keyboard.
+ * Copyright (c) 2018 BörseGo AG. All rights reserved.
+ */
+public class KeyboardEditTextPopupActivity extends AppCompatActivity  {
+
+    private static final double MAX_ALLOWED_AMOUNT = 9999.99;
+    private static final int MAX_ALLOWED_DECIMALS = 2;
+
+    private EditText amountEditText;
+    private String amountText;
+    private NumberKeyboardPopup popup;
+    private String groupingSeparator;
+    private NumberFormat numberFormat;
+
+    private static final String TAG = KeyboardPopupActivity.class.getSimpleName();
+    private char groupSeparatorChar;
+
+    private TextWatcher amountFormatWatcher = new TextWatcher() {
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+        }
+
+        @Override
+        public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+        }
+
+        @Override
+        public void afterTextChanged(Editable s) {
+            final String inputAmount = s.toString();
+            final String newAmount = updateAmount(inputAmount);
+            if (!inputAmount.equals(newAmount)) {
+                amountEditText.removeTextChangedListener(amountFormatWatcher);
+                amountEditText.setText(newAmount);
+                amountEditText.addTextChangedListener(amountFormatWatcher);
+            }
+        }
+    };
+
+    public KeyboardEditTextPopupActivity() {
+        this.amountText = "";
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_keyboard_popup);
+        setTitle("Keyboard popup with fake IME");
+        amountEditText = findViewById(R.id.amount);
+
+        numberFormat = NumberFormat.getInstance();
+        if (numberFormat instanceof DecimalFormat) {
+            DecimalFormatSymbols sym = ((DecimalFormat) numberFormat).getDecimalFormatSymbols();
+            groupSeparatorChar = sym.getGroupingSeparator();
+            groupingSeparator = String.valueOf(groupSeparatorChar);
+        }
+
+        numberFormat.setMaximumFractionDigits(MAX_ALLOWED_DECIMALS);
+
+        popup = new NumberKeyboardPopup.Builder(findViewById(R.id.main_view)).setEditTextListener().setKeyboardLayout(R.layout.popup_keyboard).build(amountEditText);
+
+        amountEditText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!popup.isShowing()) {
+                    popup.toggle();
+                }
+            }
+        });
+
+        amountEditText.addTextChangedListener(amountFormatWatcher);
+
+        amountEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                amountEditText.clearFocus();
+
+                // Because there is no other Input that can take the focus, hide the keyboard explicitly
+                final InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (inputMethodManager != null) {
+                    inputMethodManager.hideSoftInputFromWindow(amountEditText.getWindowToken(), 0);
+                }
+                return true;
+            }
+        });
+
+    }
+
+
+    public int countCommas(final String haystack) {
+        int count = 0;
+        for (int i = 0; i < haystack.length(); i++) {
+            if (haystack.charAt(i) == groupSeparatorChar) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+
+    /**
+     * Update new entered amount if it is valid.
+     *
+     * @param newAmountText   new text to parse and format
+     */
+    private String updateAmount(String newAmountText) {
+        try {
+            final int numOldCommas = countCommas(newAmountText);
+            double newAmount = newAmountText.isEmpty() ? 0.0 : numberFormat.parse(newAmountText.replace(groupingSeparator, "")).doubleValue();
+            newAmount = Math.min(newAmount, MAX_ALLOWED_AMOUNT);
+            this.amountText = numberFormat.format(newAmount);
+            return amountText.isEmpty() ? "0" : amountText;
+        } catch (ParseException e) {
+            Log.e(TAG, "Cannot parse amount '" + newAmountText + "'");
+        }
+        return newAmountText;
+    }
+
+}
+

--- a/sample/src/main/java/com/davidmiguel/sample/KeyboardFingerprintActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/KeyboardFingerprintActivity.java
@@ -48,6 +48,11 @@ public class KeyboardFingerprintActivity extends AppCompatActivity implements Nu
         showAmount();
     }
 
+    @Override
+    public void onModifierButtonClicked(int number) {
+        // Keyboard has no modifiers
+    }
+
     private void showAmount() {
         amountEditText.setText(nf.format(amount));
     }

--- a/sample/src/main/java/com/davidmiguel/sample/KeyboardIntegerActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/KeyboardIntegerActivity.java
@@ -47,6 +47,11 @@ public class KeyboardIntegerActivity extends AppCompatActivity implements Number
         showAmount();
     }
 
+    @Override
+    public void onModifierButtonClicked(int number) {
+        // Keyboard has no modifiers
+    }
+
     private void showAmount() {
         amountEditText.setText(nf.format(amount));
     }

--- a/sample/src/main/java/com/davidmiguel/sample/KeyboardPopupActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/KeyboardPopupActivity.java
@@ -1,9 +1,11 @@
 package com.davidmiguel.sample;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import com.davidmiguel.numberkeyboard.NumberKeyboardListener;
@@ -161,8 +163,12 @@ public class KeyboardPopupActivity extends AppCompatActivity implements NumberKe
                 updateAmount(newAmountText, selectionEnd > 0 ? selectionEnd - 1 : 0);
                 break;
             case 3:
-                // Enter button
-                onBackPressed();
+                // Enter button, close keyboard
+                final InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (inputMethodManager != null) {
+                    inputMethodManager.hideSoftInputFromWindow(amountEditText.getWindowToken(), 0);
+                }
+
                 break;
         }
     }

--- a/sample/src/main/java/com/davidmiguel/sample/KeyboardPopupActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/KeyboardPopupActivity.java
@@ -2,21 +2,27 @@ package com.davidmiguel.sample;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.widget.TextView;
+import android.view.View;
+import android.widget.EditText;
 
-import com.davidmiguel.numberkeyboard.NumberKeyboard;
 import com.davidmiguel.numberkeyboard.NumberKeyboardListener;
+import com.davidmiguel.numberkeyboard.NumberKeyboardPopup;
 
-public class KeyboardDecimalActivity extends AppCompatActivity implements NumberKeyboardListener {
+/**
+ * Created by Kevin Read <me@kevin-read.com> on 14.08.18 for number-keyboard.
+ * Copyright (c) 2018 BörseGo AG. All rights reserved.
+ */
+public class KeyboardPopupActivity extends AppCompatActivity implements NumberKeyboardListener {
 
     private static final double MAX_ALLOWED_AMOUNT = 9999.99;
     private static final int MAX_ALLOWED_DECIMALS = 2;
 
-    private TextView amountEditText;
+    private EditText amountEditText;
     private String amountText;
     private double amount;
+    private NumberKeyboardPopup popup;
 
-    public KeyboardDecimalActivity() {
+    public KeyboardPopupActivity() {
         this.amountText = "";
         this.amount = 0.0;
     }
@@ -24,11 +30,20 @@ public class KeyboardDecimalActivity extends AppCompatActivity implements Number
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_keyboard_decimal);
+        setContentView(R.layout.activity_keyboard_popup);
         setTitle("Keyboard decimal");
         amountEditText = findViewById(R.id.amount);
-        NumberKeyboard numberKeyboard = findViewById(R.id.numberKeyboard);
-        numberKeyboard.setListener(this);
+
+        popup = new NumberKeyboardPopup.Builder(findViewById(R.id.main_view)).setNumberKeyboardListener(this).setKeyboardLayout(R.layout.popup_keyboard).build(amountEditText);
+
+        amountEditText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!popup.isShowing()) {
+                    popup.toggle();
+                }
+            }
+        });
     }
 
     @Override
@@ -41,37 +56,44 @@ public class KeyboardDecimalActivity extends AppCompatActivity implements Number
 
     @Override
     public void onLeftAuxButtonClicked() {
-        // Comma button
-        if (!hasComma(amountText)) {
-            amountText = amountText.isEmpty() ? "0," : amountText + ",";
-            showAmount(amountText);
+        // Nothing to do
+    }
+
+    @Override
+    public void onModifierButtonClicked(int number) {
+        switch (number) {
+            case 0:
+                // Comma button
+                if (!hasComma(amountText)) {
+                    amountText = amountText.isEmpty() ? "0," : amountText + ",";
+                    showAmount(amountText);
+                }
+                break;
+            case 2:
+                // Delete button
+                if (amountText.isEmpty()) {
+                    return;
+                }
+                String newAmountText;
+                if (amountText.length() <= 1) {
+                    newAmountText = "";
+                } else {
+                    newAmountText = amountText.substring(0, amountText.length() - 1);
+                    if (newAmountText.charAt(newAmountText.length() - 1) == ',') {
+                        newAmountText = newAmountText.substring(0, newAmountText.length() - 1);
+                    }
+                    if ("0".equals(newAmountText)) {
+                        newAmountText = "";
+                    }
+                }
+                updateAmount(newAmountText);
+                break;
         }
     }
 
     @Override
     public void onRightAuxButtonClicked() {
-        // Delete button
-        if (amountText.isEmpty()) {
-            return;
-        }
-        String newAmountText;
-        if (amountText.length() <= 1) {
-            newAmountText = "";
-        } else {
-            newAmountText = amountText.substring(0, amountText.length() - 1);
-            if (newAmountText.charAt(newAmountText.length() - 1) == ',') {
-                newAmountText = newAmountText.substring(0, newAmountText.length() - 1);
-            }
-            if ("0".equals(newAmountText)) {
-                newAmountText = "";
-            }
-        }
-        updateAmount(newAmountText);
-    }
-
-    @Override
-    public void onModifierButtonClicked(int number) {
-        // Keyboard has no modifier column
+        // Nothing to do
     }
 
     /**

--- a/sample/src/main/java/com/davidmiguel/sample/MainActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/MainActivity.java
@@ -32,4 +32,9 @@ public class MainActivity extends AppCompatActivity {
         Intent intent = new Intent(this, KeyboardCustomActivity.class);
         startActivity(intent);
     }
+
+    public void openKeyboardPopup(View view) {
+        Intent intent = new Intent(this, KeyboardPopupActivity.class);
+        startActivity(intent);
+    }
 }

--- a/sample/src/main/java/com/davidmiguel/sample/MainActivity.java
+++ b/sample/src/main/java/com/davidmiguel/sample/MainActivity.java
@@ -37,4 +37,9 @@ public class MainActivity extends AppCompatActivity {
         Intent intent = new Intent(this, KeyboardPopupActivity.class);
         startActivity(intent);
     }
+
+    public void openKeyboardEditTextPopup(View view) {
+        Intent intent = new Intent(this, KeyboardEditTextPopupActivity.class);
+        startActivity(intent);
+    }
 }

--- a/sample/src/main/res/layout/activity_keyboard_popup.xml
+++ b/sample/src/main/res/layout/activity_keyboard_popup.xml
@@ -5,7 +5,7 @@
     android:id="@+id/main_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="50dp"
+    android:paddingBottom="100dp"
     tools:context="com.davidmiguel.sample.MainActivity">
 
     <LinearLayout
@@ -28,6 +28,7 @@
         android:layout_height="wrap_content"
         android:inputType="none"
         android:layout_gravity="top"
+        android:maxLines="1"
         android:gravity="top"
         android:hint="0"
         android:textSize="40sp"/>

--- a/sample/src/main/res/layout/activity_keyboard_popup.xml
+++ b/sample/src/main/res/layout/activity_keyboard_popup.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:keyboard="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="50dp"
+    tools:context="com.davidmiguel.sample.MainActivity">
+
+    <EditText
+        android:id="@+id/amount"
+        style="@style/Base.TextAppearance.AppCompat.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="64dp"
+        android:layout_gravity="center"
+        android:layout_margin="20dp"
+        android:gravity="center"
+        android:inputType="none"
+        android:text="0"
+        android:textSize="40sp"/>
+
+
+</LinearLayout>

--- a/sample/src/main/res/layout/activity_keyboard_popup.xml
+++ b/sample/src/main/res/layout/activity_keyboard_popup.xml
@@ -1,26 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:keyboard="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:padding="50dp"
     tools:context="com.davidmiguel.sample.MainActivity">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:orientation="horizontal">
+        <TextView
+            style="@style/Base.TextAppearance.AppCompat.Title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top"
+            android:text="€"
+            android:textSize="40sp"/>
 
     <EditText
         android:id="@+id/amount"
         style="@style/Base.TextAppearance.AppCompat.Title"
         android:layout_width="wrap_content"
-        android:layout_height="64dp"
-        android:layout_gravity="center"
-        android:layout_margin="20dp"
-        android:gravity="center"
+        android:layout_height="wrap_content"
         android:inputType="none"
-        android:text="0"
+        android:layout_gravity="top"
+        android:gravity="top"
+        android:hint="0"
         android:textSize="40sp"/>
+    </LinearLayout>
 
 
-</LinearLayout>
+</FrameLayout>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -17,7 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:onClick="openKeyboardInteger"
-            android:padding="30dp"
+            android:padding="16dp"
             android:text="Integer"/>
 
         <Button
@@ -25,7 +25,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:onClick="openKeyboardDecimal"
-            android:padding="30dp"
+            android:padding="16dp"
             android:text="Decimal"/>
 
         <Button
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:onClick="openKeyboardFingerprint"
-            android:padding="30dp"
+            android:padding="16dp"
             android:text="Fingerprint"/>
 
         <Button
@@ -41,7 +41,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:onClick="openKeyboardCustom"
-            android:padding="30dp"
+            android:padding="16dp"
             android:text="Custom"/>
 
         <Button
@@ -49,8 +49,16 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:onClick="openKeyboardPopup"
-            android:padding="30dp"
+            android:padding="16dp"
             android:text="Pop-Up"/>
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:onClick="openKeyboardEditTextPopup"
+            android:padding="16dp"
+            android:text="Pop-Up with EditText"/>
 
     </LinearLayout>
 </RelativeLayout>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -44,5 +44,13 @@
             android:padding="30dp"
             android:text="Custom"/>
 
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:onClick="openKeyboardPopup"
+            android:padding="30dp"
+            android:text="Pop-Up"/>
+
     </LinearLayout>
 </RelativeLayout>

--- a/sample/src/main/res/layout/popup_keyboard.xml
+++ b/sample/src/main/res/layout/popup_keyboard.xml
@@ -3,5 +3,5 @@
     xmlns:keyboard="http://schemas.android.com/apk/res-auto"
     android:background="@android:color/white"
     android:layout_width="match_parent" android:layout_height="match_parent"
-    keyboard:keyboardType="four_rows"
+    keyboard:keyboardType="four_columns"
     />

--- a/sample/src/main/res/layout/popup_keyboard.xml
+++ b/sample/src/main/res/layout/popup_keyboard.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.davidmiguel.numberkeyboard.NumberKeyboard xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:keyboard="http://schemas.android.com/apk/res-auto"
+    android:background="@android:color/white"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    keyboard:keyboardType="four_rows"
+    />


### PR DESCRIPTION
Since I want to use this instead of the number plus decimal keyboard mode that is broken on many IMEs (here's looking at you, Samsung and LG) I have added a "fake IME" mode to NumberKeyboard. You can use it alongside or instead of a NumberKeyboardListener. It will create KeyEvents and optionally IME actions and send them to the EditText that has been connected.

This way, text selection works naturally and the user can event select some text and then replace or delete it.

This builds on my "popup" work in my master branch so will depend on that being merged first, if it fits. If that work cannot be merged I can look into separating both.