### PR TITLE
Add font type attribute

### DIFF
--- a/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboard.kt
+++ b/lib/src/main/java/com/davidmiguel/numberkeyboard/NumberKeyboard.kt
@@ -7,13 +7,11 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.annotation.AttrRes
-import androidx.annotation.ColorRes
-import androidx.annotation.Dimension
-import androidx.annotation.DrawableRes
+import androidx.annotation.*
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
 import java.util.*
 
 /**
@@ -32,6 +30,7 @@ class NumberKeyboard : ConstraintLayout {
     private var numberKeyBackground: Int = 0
     @ColorRes
     private var numberKeyTextColor: Int = 0
+    private var numberKeyTypeface: Typeface? = null
     @DrawableRes
     private var leftAuxBtnIcon: Int = 0
     @DrawableRes
@@ -210,6 +209,10 @@ class NumberKeyboard : ConstraintLayout {
             // Get number key text color
             numberKeyTextColor = array.getResourceId(R.styleable.NumberKeyboard_numberkeyboard_numberKeyTextColor,
                     R.drawable.numberkeyboard_key_text_color)
+            if (array.hasValue(R.styleable.NumberKeyboard_numberkeyboard_numberKeyTypeface)) {
+                val fontId = array.getResourceId(R.styleable.NumberKeyboard_numberkeyboard_numberKeyTypeface, -1)
+                numberKeyTypeface = ResourcesCompat.getFont(context, fontId)
+            }
             // Get auxiliary icons
             when (type) {
                 0 -> { // integer
@@ -287,6 +290,10 @@ class NumberKeyboard : ConstraintLayout {
         setKeyPadding(keyPadding)
         setNumberKeyBackground(numberKeyBackground)
         setNumberKeyTextColor(numberKeyTextColor)
+        val typeface = numberKeyTypeface
+        if (typeface != null) {
+            setNumberKeyTypeface(typeface)
+        }
         setLeftAuxButtonIcon(leftAuxBtnIcon)
         setLeftAuxButtonBackground(leftAuxBtnBackground)
         setRightAuxButtonIcon(rightAuxBtnIcon)

--- a/lib/src/main/res/values/attrs.xml
+++ b/lib/src/main/res/values/attrs.xml
@@ -23,6 +23,7 @@
         <attr name="numberkeyboard_keyPadding" format="dimension"/>
         <attr name="numberkeyboard_numberKeyBackground" format="reference"/>
         <attr name="numberkeyboard_numberKeyTextColor" format="reference"/>
+        <attr name="numberkeyboard_numberKeyTypeface" format="reference"/>
         <attr name="numberkeyboard_leftAuxBtnIcon" format="reference"/>
         <attr name="numberkeyboard_leftAuxBtnBackground" format="reference"/>
         <attr name="numberkeyboard_rightAuxBtnIcon" format="reference"/>


### PR DESCRIPTION
Referencing this issue #17 
This add `numberKeyTypeface` attribute to NumberKeyboard
```xml
<com.davidmiguel.numberkeyboard.NumberKeyboard
    xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:keyboard="http://schemas.android.com/apk/res-auto"
    ...
    keyboard:numberkeyboard_numberKeyTypeface="@font/montserrat_bold"
    ... />
```