### PR TITLE
Bump gradle/gradle plugin and Kotlin version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,9 +5,9 @@ ext {
     //----------------------------------------------------------------------------------------------
 
     // Android Plugin for Gradle : https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google | https://developer.android.com/studio/releases/gradle-plugin.html#updating-plugin
-    androidGradle = '3.4.0-alpha08'
+    androidGradle = '4.0.0'
     // Kotlin version : https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-gradle-plugin
-    kotlin = '1.3.11'
+    kotlin = '1.3.72'
 
     gradleDependencies = [
             androidGradle: "com.android.tools.build:gradle:${androidGradle}",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-milestone-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 ext.versionMajor = 3 // API Changes, adding big new feature, redesign the App
 ext.versionMinor = 0 // New features in a backwards-compatible manner

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 ext.versionMajor = 1 // API Changes, adding big new feature, redesign the App
 ext.versionMinor = 0 // New features in a backwards-compatible manner


### PR DESCRIPTION
Hi there, I was having issues with gradle after pulling the repo. Proposing this PR to bump gradle/gradle plugin versions and Kotlin version.

This PR addresses the following:
1. Build error
![image](https://user-images.githubusercontent.com/2370877/84185112-1dabe200-aa54-11ea-8464-9bc332e79b5c.png)
(Android Studio 3.6.1, auto-update will resolve the issue) 

However, with Android Studio 4.0, auto-update option for plugins actually fails with the following message:
![build-failed-message](https://user-images.githubusercontent.com/2370877/84186446-2998a380-aa56-11ea-9bb1-472159241907.png)
(This pr fixes this issue)

2. Build warning
![build-warning-message](https://user-images.githubusercontent.com/2370877/84186550-4f25ad00-aa56-11ea-9666-02fb927cc392.png)
(This pr fixes this issue)

Thank you for the library.