### PR TITLE
Bump Dependency Versions, Add Demo for Custom Square Design

### DIFF
--- a/configurations.gradle
+++ b/configurations.gradle
@@ -3,10 +3,9 @@ ext {
     javaVersion = JavaVersion.VERSION_1_8
 
     androidConfig = [
-            buildToolsVersion: "28.0.3", // https://developer.android.com/studio/releases/build-tools
             minSdkVersion    : 19,
-            targetSdkVersion : 28,
-            compileSdkVersion: 28
+            targetSdkVersion : 31,
+            compileSdkVersion: 31
     ]
 
     /**

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,9 +5,9 @@ ext {
     //----------------------------------------------------------------------------------------------
 
     // Android Plugin for Gradle : https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google | https://developer.android.com/studio/releases/gradle-plugin.html#updating-plugin
-    androidGradle = '4.0.0'
+    androidGradle = '7.2.2'
     // Kotlin version : https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-gradle-plugin
-    kotlin = '1.3.72'
+    kotlin = '1.7.10'
 
     gradleDependencies = [
             androidGradle: "com.android.tools.build:gradle:${androidGradle}",
@@ -19,13 +19,13 @@ ext {
     //----------------------------------------------------------------------------------------------
 
     // AndroidX Core : https://mvnrepository.com/artifact/androidx.core/core | https://developer.android.com/jetpack/androidx/androidx-rn
-    androidXCore = "1.0.1"
+    androidXCore = "1.8.0"
     // AppCompat : https://mvnrepository.com/artifact/androidx.appcompat/appcompat | https://developer.android.com/topic/libraries/support-library/packages#v7-appcompat
-    appcompat = '1.0.2'
+    appcompat = '1.4.2'
     // Android Annotations : https://mvnrepository.com/artifact/androidx.annotation/annotation?repo=google | https://developer.android.com/topic/libraries/support-library/packages#annotations
-    annotations = "1.0.1"
+    annotations = "1.4.0"
     // ConstraintLayout : https://mvnrepository.com/artifact/androidx.constraintlayout/constraintlayout
-    constraintLayout = '1.1.3'
+    constraintLayout = '2.1.4'
 
     appDependencies = [
             androidXCore    : "androidx.core:core:${androidXCore}",
@@ -40,7 +40,7 @@ ext {
     //----------------------------------------------------------------------------------------------
 
     // Timber (logger) : https://mvnrepository.com/artifact/com.jakewharton.timber/timber | https://github.com/JakeWharton/timber
-    timber = '4.7.1'
+    timber = '5.0.1'
 
     debugDependencies = [
             timber: "com.jakewharton.timber:timber:${timber}",
@@ -51,9 +51,9 @@ ext {
     //----------------------------------------------------------------------------------------------
 
     // JUnit (unit testing framework) : https://mvnrepository.com/artifact/junit/junit | http://junit.org/junit4/
-    junit = '4.12'
+    junit = '4.13.2'
     // Mockito (mocking framework) : https://mvnrepository.com/artifact/org.mockito/mockito-core | http://site.mockito.org/
-    mockito = '2.23.4'
+    mockito = '4.6.1'
 
     testDependencies = [
             junit  : "junit:junit:${junit}",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -9,7 +9,6 @@ ext.versionClassifier = null // Pre-releases (alpha, beta, rc, SNAPSHOT...)
 
 android {
     compileSdkVersion androidConfig.compileSdkVersion
-    buildToolsVersion androidConfig.buildToolsVersion
 
     defaultConfig {
         minSdkVersion androidConfig.minSdkVersion

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,7 +9,6 @@ ext.versionClassifier = null // Pre-releases (alpha, beta, rc, SNAPSHOT...)
 
 android {
     compileSdkVersion androidConfig.compileSdkVersion
-    buildToolsVersion androidConfig.buildToolsVersion
 
     defaultConfig {
         applicationId "com.davidmiguel.numberkeyboard.sample"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.davidmiguel.sample">
+    package="com.davidmiguel.sample">
 
     <application
         android:allowBackup="true"
@@ -9,19 +9,32 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
         <activity android:name="com.davidmiguel.sample.KeyboardIntegerActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardDecimalActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardFingerprintActivity" />
-        <activity android:name="com.davidmiguel.sample.KeyboardCustomActivity" />
+        <activity
+            android:name="com.davidmiguel.sample.KeyboardCustomActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
 
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="com.davidmiguel.sample"
+                    android:pathPattern="/KeyboardCustomActivity"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
     </application>
-
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -21,8 +21,9 @@
         <activity android:name="com.davidmiguel.sample.KeyboardIntegerActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardDecimalActivity" />
         <activity android:name="com.davidmiguel.sample.KeyboardFingerprintActivity" />
+        <activity android:name="com.davidmiguel.sample.KeyboardCustomActivity" />
         <activity
-            android:name="com.davidmiguel.sample.KeyboardCustomActivity"
+            android:name="com.davidmiguel.sample.KeyboardCustomSquareActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -32,7 +33,7 @@
 
                 <data
                     android:host="com.davidmiguel.sample"
-                    android:pathPattern="/KeyboardCustomActivity"
+                    android:pathPattern="/KeyboardCustomSquareActivity"
                     android:scheme="https" />
             </intent-filter>
         </activity>

--- a/sample/src/main/java/com/davidmiguel/sample/KeyboardCustomSquareActivity.kt
+++ b/sample/src/main/java/com/davidmiguel/sample/KeyboardCustomSquareActivity.kt
@@ -1,0 +1,130 @@
+package com.davidmiguel.sample
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.davidmiguel.numberkeyboard.NumberKeyboard
+import com.davidmiguel.numberkeyboard.NumberKeyboardListener
+
+class KeyboardCustomSquareActivity : AppCompatActivity(), NumberKeyboardListener {
+
+    private lateinit var amountEditText: TextView
+    private var amountText: String = ""
+    private var amount: Double = 0.0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_keyboard_custom_square)
+        title = "Keyboard custom square"
+        amountEditText = findViewById(R.id.amount)
+        val numberKeyboard = findViewById<NumberKeyboard>(R.id.numberKeyboard)
+        numberKeyboard.setListener(this)
+    }
+
+    override fun onNumberClicked(number: Int) {
+        if (amountText.isEmpty() && number == 0) {
+            return
+        }
+        updateAmount(amountText + number)
+    }
+
+    override fun onLeftAuxButtonClicked() {
+        // Comma button
+        if (!hasComma(amountText)) {
+            amountText = if (amountText.isEmpty()) "0," else "$amountText,"
+            showAmount(amountText)
+        }
+    }
+
+    override fun onRightAuxButtonClicked() {
+        // Delete button
+        if (amountText.isEmpty()) {
+            return
+        }
+        var newAmountText: String
+        if (amountText.length <= 1) {
+            newAmountText = ""
+        } else {
+            newAmountText = amountText.substring(0, amountText.length - 1)
+            if (newAmountText[newAmountText.length - 1] == ',') {
+                newAmountText = newAmountText.substring(0, newAmountText.length - 1)
+            }
+            if ("0" == newAmountText) {
+                newAmountText = ""
+            }
+        }
+        updateAmount(newAmountText)
+    }
+
+    /**
+     * Update new entered amount if it is valid.
+     */
+    private fun updateAmount(newAmountText: String) {
+        val newAmount = if (newAmountText.isEmpty()) 0.0 else java.lang.Double.parseDouble(newAmountText.replace(",".toRegex(), "."))
+        if (newAmount in 0.0..MAX_ALLOWED_AMOUNT
+            && getNumDecimals(newAmountText) <= MAX_ALLOWED_DECIMALS
+        ) {
+            amountText = newAmountText
+            amount = newAmount
+            showAmount(amountText)
+        }
+    }
+
+    /**
+     * Add . every thousand.
+     */
+    private fun addThousandSeparator(amount: String): String {
+        var integer: String
+        val decimal: String
+        if (amount.indexOf(',') >= 0) {
+            integer = amount.substring(0, amount.indexOf(','))
+            decimal = amount.substring(amount.indexOf(','), amount.length)
+        } else {
+            integer = amount
+            decimal = ""
+        }
+        if (integer.length > 3) {
+            val tmp = StringBuilder(integer)
+            var i = integer.length - 3
+            while (i > 0) {
+                tmp.insert(i, ".")
+                i = i - 3
+            }
+            integer = tmp.toString()
+        }
+        return integer + decimal
+    }
+
+    /**
+     * Shows amount in UI.
+     */
+    private fun showAmount(amount: String) {
+        amountEditText.text = "€" + if (amount.isEmpty()) "0" else addThousandSeparator(amount)
+    }
+
+    /**
+     * Checks whether the string has a comma.
+     */
+    private fun hasComma(text: String): Boolean {
+        for (i in 0 until text.length) {
+            if (text[i] == ',') {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Calculate the number of decimals of the string.
+     */
+    private fun getNumDecimals(num: String): Int {
+        return if (!hasComma(num)) {
+            0
+        } else num.substring(num.indexOf(',') + 1, num.length).length
+    }
+
+    companion object {
+        private const val MAX_ALLOWED_AMOUNT = 9999.99
+        private const val MAX_ALLOWED_DECIMALS = 2
+    }
+}

--- a/sample/src/main/java/com/davidmiguel/sample/MainActivity.kt
+++ b/sample/src/main/java/com/davidmiguel/sample/MainActivity.kt
@@ -2,8 +2,8 @@ package com.davidmiguel.sample
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
 
@@ -29,6 +29,11 @@ class MainActivity : AppCompatActivity() {
 
     fun openKeyboardCustom(view: View) {
         val intent = Intent(this, KeyboardCustomActivity::class.java)
+        startActivity(intent)
+    }
+
+    fun openKeyboardCustomSquare(view: View) {
+        val intent = Intent(this, KeyboardCustomSquareActivity::class.java)
         startActivity(intent)
     }
 }

--- a/sample/src/main/res/drawable/key_bg_rounded_square.xml
+++ b/sample/src/main/res/drawable/key_bg_rounded_square.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/key_bg_rounded_square_pressed" android:state_pressed="true" />
+    <item android:drawable="@drawable/key_bg_rounded_square_normal" />
+</selector>

--- a/sample/src/main/res/drawable/key_bg_rounded_square_normal.xml
+++ b/sample/src/main/res/drawable/key_bg_rounded_square_normal.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <stroke
+        android:width="1dp"
+        android:color="#CACACA" />
+</shape>

--- a/sample/src/main/res/drawable/key_bg_rounded_square_pressed.xml
+++ b/sample/src/main/res/drawable/key_bg_rounded_square_pressed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="8dp" />
+    <solid android:color="#B3B3B3" />
+</shape>

--- a/sample/src/main/res/layout/activity_keyboard_custom_square.xml
+++ b/sample/src/main/res/layout/activity_keyboard_custom_square.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:keyboard="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.davidmiguel.sample.MainActivity">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineTop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="16dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineBottom"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_end="16dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineStart"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="16dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guidelineEnd"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="16dp" />
+
+    <TextView
+        android:id="@+id/amount"
+        style="@style/Base.TextAppearance.AppCompat.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:layout_gravity="center"
+        android:layout_margin="20dp"
+        android:gravity="center"
+        android:text="0"
+        android:textSize="40sp"
+        keyboard:layout_constraintEnd_toEndOf="parent"
+        keyboard:layout_constraintStart_toStartOf="parent"
+        keyboard:layout_constraintTop_toTopOf="parent" />
+
+    <com.davidmiguel.numberkeyboard.NumberKeyboard
+        android:id="@+id/numberKeyboard"
+        android:layout_width="0dp"
+        android:layout_height="280dp"
+        app:layout_constraintBottom_toBottomOf="@id/guidelineBottom"
+        app:layout_constraintEnd_toEndOf="@id/guidelineEnd"
+        app:layout_constraintStart_toStartOf="@id/guidelineStart"
+        keyboard:numberkeyboard_keyHeight="64dp"
+        keyboard:numberkeyboard_keyPadding="8dp"
+        keyboard:numberkeyboard_keyWidth="96dp"
+        keyboard:numberkeyboard_keyboardType="custom"
+        keyboard:numberkeyboard_leftAuxBtnBackground="@drawable/key_bg_rounded_square"
+        keyboard:numberkeyboard_leftAuxBtnIcon="@drawable/numberkeyboard_ic_comma"
+        keyboard:numberkeyboard_numberKeyBackground="@drawable/key_bg_rounded_square"
+        keyboard:numberkeyboard_numberKeyTextColor="@android:color/black"
+        keyboard:numberkeyboard_rightAuxBtnBackground="@drawable/key_bg_rounded_square"
+        keyboard:numberkeyboard_rightAuxBtnIcon="@drawable/numberkeyboard_ic_backspace_normal" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -44,5 +44,13 @@
             android:padding="30dp"
             android:text="Custom" />
 
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:onClick="openKeyboardCustomSquare"
+            android:padding="30dp"
+            android:text="Custom Square" />
+
     </LinearLayout>
 </RelativeLayout>


### PR DESCRIPTION
After tweaking around the few places to try getting the rounded square to work, apparently it's able to support it.

I've added design in the sample to showcase how easily it can achieved by tweaking these.
```
keyboard:numberkeyboard_numberKeyBackground
keyboard:numberkeyboard_leftAuxBtnBackground
keyboard:numberkeyboard_rightAuxBtnBackground
```
I've took the liberty to also update the dependency versions, as well.

TLDR; Just updated dependencies, added a new demo variant with no API changes.

https://user-images.githubusercontent.com/12107271/184605626-4a7224ca-1b06-4e5d-946e-ca79c4990e01.mp4

