### PR TITLE
Removed `onAmountChange: (String) -> Unit` and merge with `NumberKeyboardListener` implementation, Fixed  `rawAmount` having 0 in front.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ dependencies {
 
 [CHANGELOG](https://github.com/davidmigloz/number-keyboard/blob/master/CHANGELOG.md)
 
+## [5.0.2]
+
+- Fixed  `rawAmount` having 0 in front.
+
+### ⚠️ Breaking Changes
+
+- Removed `onAmountChange: (String) -> Unit` and merge with `NumberKeyboardListener` implementation.
+
+**🧭 Migration Guide**
+
+```kotlin
+var amountWithCurrency by remember { mutableStateOf("$currencySymbol 0") }
+var amount by remember { mutableStateOf("") }
+
+NumberKeyboard(
+    amount = amount,
+    listener = object : NumberKeyboardListener {
+        override fun onUpdated(data: NumberKeyboardData) {
+            amountWithCurrency = data.currency
+            amount = data.rawAmount
+        }
+    }
+)
+```
+
 ## [5.0.0] - Kotlin Multiplatform Version
 
 ### ✨ New Features
@@ -113,11 +138,11 @@ NumberKeyboard(
 #### Use `NumberKeyboard` Composable in your layout:
 
 ```kotlin
+var amountWithCurrency by remember { mutableStateOf("$currencySymbol 0") }
 var amount by remember { mutableStateOf("") }
 
 NumberKeyboard(
     amount = amount,
-    onAmountChanged = { amount = it },
     maxAllowedAmount = 999.00,
     maxAllowedDecimals = 0,
     roundUpToMax = false,
@@ -148,7 +173,8 @@ NumberKeyboard(
     },
     listener = object : NumberKeyboardListener {
         override fun onUpdated(data: NumberKeyboardData) {
-            text = data.int.toString()
+          amountWithCurrency = data.currency
+          amount = data.rawAmount
         }
     }
 )
@@ -157,17 +183,17 @@ NumberKeyboard(
 ##### Attribute
 
 - `amount` - String: Variable that keeps
-- `onAmountChanged` - (String)-> Unit:
 - `maxAllowedAmount` - Double (default: 10_000.0): Maximum amount allowed for the `NumberKeyboard`
   output
 - `maxAllowedDecimals` - Int (default: 2): Maximum decimal points allowed for the `NumberKeyboard`
   output
 - `currencySymbol` - String (default: "$"): Currency symbol for the `NumberKeyboardData` currency
 - `format` Enum(default: NumberKeyboardFormat.Normal) Defines the layout of the number pad. Options:
-  •	Normal: Standard ascending layout (1–9 top to bottom, like a phone dial pad).
-  •	Inverted: Descending layout (9–1 top to bottom, like a calculator).
-  •	Scrambled: Digits are shuffled once at composition.
-  •	AlwaysScrambled: Digits reshuffle every time the user taps a key — great for max security or mild chaos.
+  • Normal: Standard ascending layout (1–9 top to bottom, like a phone dial pad).
+  • Inverted: Descending layout (9–1 top to bottom, like a calculator).
+  • Scrambled: Digits are shuffled once at composition.
+  • AlwaysScrambled: Digits reshuffle every time the user taps a key — great for max security or
+  mild chaos.
 - `roundUpToMax` - Boolean (default: true): Behaviour to round up to the max allowed amount if
   amount has exceeded
 - `verticalArrangement` - Arrangement.HorizontalOrVertical (default: 8.dp): Vertical spacing between

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 val versionMajor = 5 // API Changes, adding big new feature, redesign the App
 val versionMinor = 0 // New features in a backwards-compatible manner
-val versionPatch = 1 // Backwards-compatible bug fixes
+val versionPatch = 2 // Backwards-compatible bug fixes
 val versionClassifier: String? = null // Pre-releases (alpha, beta, rc, SNAPSHOT...)
 
 kotlin {

--- a/lib/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/NumberKeyboard.kt
+++ b/lib/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/NumberKeyboard.kt
@@ -17,7 +17,6 @@ import kotlin.math.pow
 @Composable
 fun NumberKeyboard(
     amount: String,
-    onAmountChanged: (String) -> Unit,
     maxAllowedAmount: Double = 10_000.0,
     maxAllowedDecimals: Int = 2,
     currencySymbol: String = "$",
@@ -69,17 +68,15 @@ fun NumberKeyboard(
     val clickedListener = object : NumberKeyboardClickedListener {
         override fun onNumberClicked(number: Int) {
             if (amount.isEmpty() && number == 0) return
-            val appended = amount + number.toString()
+            val appended = if (amount == "0") number.toString() else amount + number.toString()
             val standardised = appended.replace(',', '.').toDoubleOrNull() ?: 0.0
 
             if (getNumberOfDecimals(appended, decimalSeparator) > maxAllowedDecimals) return
 
             if (standardised in 0.0..maxAllowedAmount) {
-                onAmountChanged(appended)
                 listener?.onUpdated(NumberKeyboardData(appended, decimalSeparator, groupingSeparator, currencySymbol))
             } else if (roundUpToMax) {
                 val maxAmount = formatMaxAmount(maxAllowedAmount, maxAllowedDecimals, decimalSeparator)
-                onAmountChanged(maxAmount)
                 listener?.onUpdated(NumberKeyboardData(maxAmount, decimalSeparator, groupingSeparator, currencySymbol))
             }
         }
@@ -91,7 +88,6 @@ fun NumberKeyboard(
                 } else {
                     "$amount$decimalSeparator"
                 }
-                onAmountChanged(updated)
                 listener?.onUpdated(NumberKeyboardData(updated, decimalSeparator, groupingSeparator, currencySymbol))
             }
         }
@@ -110,7 +106,6 @@ fun NumberKeyboard(
             }
 
             val updated = if (cleanedAmount.length <= 1) "" else cleanedAmount.dropLast(1)
-            onAmountChanged(updated)
             listener?.onUpdated(NumberKeyboardData(updated, decimalSeparator, groupingSeparator, currencySymbol))
         }
     }

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 val versionMajor = 3 // API Changes, adding big new feature, redesign the App
 val versionMinor = 0 // New features in a backwards-compatible manner
-val versionPatch = 0 // Backwards-compatible bug fixes
+val versionPatch = 1 // Backwards-compatible bug fixes
 val versionClassifier: String? = null // Pre-releases (alpha, beta, rc, SNAPSHOT...)
 
 kotlin {

--- a/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/BiometricScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/BiometricScreen.kt
@@ -54,10 +54,10 @@ fun BiometricScreen(innerPadding: PaddingValues) {
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        var text by remember { mutableStateOf("0") }
+        var amount by remember { mutableStateOf("0") }
 
         Text(
-            text = text,
+            text = amount,
             style = MaterialTheme.typography.displayLarge,
         )
 
@@ -67,10 +67,8 @@ fun BiometricScreen(innerPadding: PaddingValues) {
             .weight(1F)
             .height(48.dp)
         val buttonTextStyle = MaterialTheme.typography.titleMedium
-        var amount by remember { mutableStateOf("") }
         NumberKeyboard(
             amount = amount,
-            onAmountChanged = { amount = it },
             maxAllowedAmount = 9_999.00,
             maxAllowedDecimals = 0,
             roundUpToMax = false,
@@ -87,9 +85,7 @@ fun BiometricScreen(innerPadding: PaddingValues) {
                     modifier = buttonModifier,
                     textStyle = buttonTextStyle,
                     imageVector = Icons.Rounded.Fingerprint,
-                    clicked = {
-//                        Toast.makeText(context, "Biometrics Triggered", Toast.LENGTH_SHORT).show()
-                    }
+                    clicked = {}
                 )
             },
             rightAuxButton = { clickedListener ->
@@ -102,7 +98,7 @@ fun BiometricScreen(innerPadding: PaddingValues) {
             },
             listener = object : NumberKeyboardListener {
                 override fun onUpdated(data: NumberKeyboardData) {
-                    text = data.int.toString()
+                    amount = data.int.toString()
                 }
             }
         )

--- a/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/CustomScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/CustomScreen.kt
@@ -89,10 +89,11 @@ fun CustomScreen(innerPadding: PaddingValues) {
             }
         }
 
-        var text by remember { mutableStateOf("$currencySymbol 0") }
+        var amountWithCurrency by remember { mutableStateOf("$currencySymbol 0") }
+        var amount by remember { mutableStateOf("") }
 
         Text(
-            text = text,
+            text = amountWithCurrency,
             style = MaterialTheme.typography.displayLarge,
         )
 
@@ -102,10 +103,8 @@ fun CustomScreen(innerPadding: PaddingValues) {
             .weight(1F)
             .aspectRatio(1F)
         val buttonTextStyle = MaterialTheme.typography.titleMedium
-        var amount by remember { mutableStateOf("") }
         NumberKeyboard(
             amount = amount,
-            onAmountChanged = { amount = it },
             maxAllowedAmount = 8_888.888,
             maxAllowedDecimals = 3,
             currencySymbol = currencySymbol,
@@ -141,7 +140,8 @@ fun CustomScreen(innerPadding: PaddingValues) {
             groupingSeparator = getGroupingSeparator(),
             listener = object : NumberKeyboardListener {
                 override fun onUpdated(data: NumberKeyboardData) {
-                    text = data.currency
+                    amountWithCurrency = data.currency
+                    amount = data.rawAmount
                 }
             }
         )

--- a/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/DecimalScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/DecimalScreen.kt
@@ -46,10 +46,11 @@ fun DecimalScreen(innerPadding: PaddingValues) {
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        var text by remember { mutableStateOf("$currencySymbol 0") }
+        var amountWithCurrency by remember { mutableStateOf("$currencySymbol 0") }
+        var amount by remember { mutableStateOf("") }
 
         Text(
-            text = text,
+            text = amountWithCurrency,
             style = MaterialTheme.typography.displayLarge,
         )
 
@@ -59,10 +60,8 @@ fun DecimalScreen(innerPadding: PaddingValues) {
             .weight(1F)
             .height(48.dp)
         val buttonTextStyle = MaterialTheme.typography.titleMedium
-        var amount by remember { mutableStateOf("") }
         NumberKeyboard(
             amount = amount,
-            onAmountChanged = { amount = it },
             button = { number, clickedListener ->
                 NumberKeyboardButton(
                     modifier = buttonModifier,
@@ -89,7 +88,8 @@ fun DecimalScreen(innerPadding: PaddingValues) {
             },
             listener = object : NumberKeyboardListener {
                 override fun onUpdated(data: NumberKeyboardData) {
-                    text = data.currency
+                    amountWithCurrency = data.currency
+                    amount = data.rawAmount
                 }
             }
         )

--- a/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/IntegerScreen.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/davidmiguel/numberkeyboard/sample/IntegerScreen.kt
@@ -51,10 +51,10 @@ fun IntegerScreen(innerPadding: PaddingValues) {
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        var text by remember { mutableStateOf("0") }
+        var amount by remember { mutableStateOf("0") }
 
         Text(
-            text = text,
+            text = amount,
             style = MaterialTheme.typography.displayLarge,
         )
 
@@ -64,10 +64,8 @@ fun IntegerScreen(innerPadding: PaddingValues) {
             .weight(1F)
             .height(48.dp)
         val buttonTextStyle = MaterialTheme.typography.titleMedium
-        var amount by remember { mutableStateOf("") }
         NumberKeyboard(
             amount = amount,
-            onAmountChanged = { amount = it },
             maxAllowedDecimals = 0,
             button = { number, clickedListener ->
                 NumberKeyboardButton(
@@ -87,7 +85,7 @@ fun IntegerScreen(innerPadding: PaddingValues) {
             },
             listener = object : NumberKeyboardListener {
                 override fun onUpdated(data: NumberKeyboardData) {
-                    text = data.int.toString()
+                    amount = data.int.toString()
                 }
             }
         )


### PR DESCRIPTION
## [5.0.2]

- Fixed  `rawAmount` having 0 in front.

### ⚠️ Breaking Changes

- Removed `onAmountChange: (String) -> Unit` and merge with `NumberKeyboardListener` implementation.

**🧭 Migration Guide**

```kotlin
var amountWithCurrency by remember { mutableStateOf("$currencySymbol 0") }
var amount by remember { mutableStateOf("") }

NumberKeyboard(
    amount = amount,
    listener = object : NumberKeyboardListener {
        override fun onUpdated(data: NumberKeyboardData) {
            amountWithCurrency = data.currency
            amount = data.rawAmount
        }
    }
)
```